### PR TITLE
多端适配，解决<class 'aiocqhttp.exceptions.ApiNotAvailable'>报错

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /config.json
 
 data/*
+
+__pycache__/

--- a/__init__.py
+++ b/__init__.py
@@ -1,5 +1,9 @@
+import traceback
 from hoshino import Service, priv, get_bot
 import os
+
+import hoshino
+import nonebot
 from .get_morning import *
 from .get_night import *
 from .charge import *
@@ -23,6 +27,8 @@ sv_help = '''== 命令 ==
 [晚安关闭 xx] 关闭某个配置
 [晚安设置 xx x] 设置数值'''.strip()
 
+bot = nonebot.get_bot()
+
 def get_sex_str(sex,setting):
     if not setting:
         if sex == 'male':
@@ -35,6 +41,18 @@ def get_sex_str(sex,setting):
         sex_str = '美少女'
     return sex_str
 
+async def get_groups():
+    '''
+    获取群列表，支持多cq端
+    '''
+    gl = []
+    for sid in hoshino.get_self_ids():
+        gl_ = await bot.get_group_list(self_id=sid)
+        for g in gl_:
+            if g not in gl:
+                gl.append(g)
+    return gl
+
 #帮助界面
 @sv.on_fullmatch('早安晚安帮助')
 async def help(bot, ev):
@@ -44,7 +62,7 @@ async def help(bot, ev):
 async def create_json_daily():
     bot = get_bot()
     try:
-        group_list = await bot.get_group_list()
+        group_list = await get_groups()
         all_num = len(group_list)
         num = 0
         for each_g in group_list:
@@ -76,7 +94,7 @@ async def create_json(bot, ev):
         await bot.send(ev, msg)
         return
     try:
-        group_list = await bot.get_group_list()
+        group_list = await get_groups()
         all_num = len(group_list)
         num = 0
         for each_g in group_list:
@@ -99,6 +117,7 @@ async def create_json(bot, ev):
             msg = f'检测到{all_num}个群的配置信息均已存在，无需再次初始化'
     except:
         msg = '早安晚安初始化失败！'
+        traceback.print_exc()
     await bot.send(ev, msg)
 
 @sv.on_fullmatch('早安',"早","早上好","起床")
@@ -125,7 +144,7 @@ async def good_night(bot, ev):
 @sv.scheduled_job('cron', hour='23', minute='59')
 async def reset_data():
     bot = get_bot()
-    group_list = await bot.get_group_list()
+    group_list = await get_groups()
     for each_g in group_list:
         group_id = each_g['group_id']
         current_dir = os.path.join(os.path.dirname(__file__), f'data/{group_id}.json')

--- a/__init__.py
+++ b/__init__.py
@@ -27,8 +27,6 @@ sv_help = '''== 命令 ==
 [晚安关闭 xx] 关闭某个配置
 [晚安设置 xx x] 设置数值'''.strip()
 
-bot = nonebot.get_bot()
-
 def get_sex_str(sex,setting):
     if not setting:
         if sex == 'male':
@@ -45,6 +43,7 @@ async def get_groups():
     '''
     获取群列表，支持多cq端
     '''
+    bot = nonebot.get_bot()
     gl = []
     for sid in hoshino.get_self_ids():
         gl_ = await bot.get_group_list(self_id=sid)


### PR DESCRIPTION
## 错误日志

```
[2022-10-15 23:59:00,004 good_morning] ERROR: <class 'aiocqhttp.exceptions.ApiNotAvailable'> occured when doing scheduled job reset_data.
[2022-10-15 23:59:00,004 good_morning] ERROR: 
Traceback (most recent call last):
  File "C:\Users\Administrator\qqbot\HoshinoBot\hoshino\service.py", line 349, in wrapper
    ret = await func()
  File "C:\Users\Administrator\qqbot\HoshinoBot\hoshino\modules\good_morning\__init__.py", line 128, in reset_data
    group_list = await bot.get_group_list()
  File "C:\Users\Administrator\AppData\Local\Programs\Python\Python38\lib\site-packages\aiocqhttp\__init__.py", line 238, in call_action
    return await self._api.call_action(action=action, **params)
  File "C:\Users\Administrator\AppData\Local\Programs\Python\Python38\lib\site-packages\aiocqhttp\api_impl.py", line 191, in call_action
    raise ApiNotAvailable
aiocqhttp.exceptions.ApiNotAvailable
```

## 解决办法

群列表获取错误，原因是未支持多cq端，现增加支持多cq端的获取群列表函数，并排除多个bot在同一个群中产生的重复群号。

```python
async def get_groups():
    '''
    获取群列表，支持多cq端
    '''
    gl = []
    for sid in hoshino.get_self_ids():
        gl_ = await bot.get_group_list(self_id=sid)
        for g in gl_:
            if g not in gl:
                gl.append(g)
    return gl
```